### PR TITLE
[CN-1890] disable deploy options

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,46 @@ those existing conventions if you need an integration point that doesn't already
 
 Interested in sharing feedback on Spinnaker's UI or contributing to Deck?
 Please join us at the [Spinnaker UI SIG](https://github.com/spinnaker/governance/tree/master/sig-ui-ux)!
+
+<hr>
+
+# THD-DECK Docs
+
+<hr>
+
+## THD-Deck Sandbox Installation Instructions
+
+### Build a local image
+- `yarn`
+- `yarn modules`
+- `yarn build`
+
+
+### Push the local image to Artifactory
+Once you build a local image, run the following commands:
+
+```shell
+THD_DECK_VERSION={new image number}
+```
+```shell
+docker build --platform linux/amd64 -f Dockerfile.ubuntu -t docker.artifactory.homedepot.com/cd/thd-deck:${THD_DECK_VERSION} .
+```
+```shell
+docker tag docker.artifactory.homedepot.com/cd/thd-deck:${THD_DECK_VERSION} us.gcr.io/np-te-cd-tools/cd/thd-deck:${THD_DECK_VERSION}
+```
+```shell
+docker push docker.artifactory.homedepot.com/cd/thd-deck:${THD_DECK_VERSION}
+```
+
+### Push the image from Artifactory to GCR
+Once the image is pushed to docker.artifactory a Slingshot stage needs to be used
+to move the image from Artifactory to GCR.
+
+Example [pipeline](https://sandbox.spinnaker.homedepot.com/#/applications/cd-thd-deck/executions?pipeline=Push%20Deck%20Image)
+
+### Update Deck image in spin-operator repository
+In spin-operator-np-te-cd-tools repository:
+1. Create branch named for new Deck version"
+2. In deploy/spinnaker/np-te-cd-tools/overlays/us-dev1/service-settings.yml
+3. Update artifactId with new `THD_DECK_VERSION`
+   1. `artifactId: us.gcr.io/np-te-cd-tools/cd/thd-deck:${THD_DECK_VERSION}`

--- a/packages/appengine/src/loadBalancer/details/details.html
+++ b/packages/appengine/src/loadBalancer/details/details.html
@@ -27,7 +27,7 @@
             Load Balancer Actions <span class="caret"></span>
           </button>
           <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-            <li><a href ng-click="ctrl.editLoadBalancer()">Edit Load Balancer</a></li>
+            <li class="disabled"><a>Edit Load Balancer</a></li>
             <li ng-if="ctrl.canDeleteLoadBalancer()">
               <a href ng-click="ctrl.deleteLoadBalancer()">Delete Load Balancer</a>
             </li>

--- a/packages/appengine/src/serverGroup/details/details.html
+++ b/packages/appengine/src/serverGroup/details/details.html
@@ -62,8 +62,9 @@
             uib-tooltip="It is not possible to clone an App Engine server group's full
                            launch configuration. However, clicking this button will allow
                            you to deploy into this server group's cluster."
+            class="disabled"
           >
-            <a href ng-click="ctrl.cloneServerGroup()">Clone</a>
+            <a>Clone</a>
           </li>
         </ul>
       </div>

--- a/packages/azure/src/loadBalancer/details/loadBalancerDetail.html
+++ b/packages/azure/src/loadBalancer/details/loadBalancerDetail.html
@@ -27,7 +27,7 @@
             Load Balancer Actions <span class="caret"></span>
           </button>
           <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-            <li><a href ng-click="ctrl.editLoadBalancer()">Edit Load Balancer</a></li>
+            <li class="disabled"><a>Edit Load Balancer</a></li>
             <li ng-if="!loadBalancer.serverGroups.length">
               <a href ng-click="ctrl.deleteLoadBalancer()">Delete Load Balancer</a>
             </li>

--- a/packages/core/src/cluster/allClusters.html
+++ b/packages/core/src/cluster/allClusters.html
@@ -40,7 +40,7 @@
   </div>
   <div class="col-lg-3 col-md-2 col-sm-2">
     <div class="application-actions">
-      <button class="btn btn-sm btn-default" ng-click="ctrl.createServerGroup()" ng-hide="isDisabled">
+      <button class="btn btn-sm btn-default disabled">
         <span class="glyphicon glyphicon-plus-sign visible-lg-inline"></span>
         <span
           class="glyphicon glyphicon-plus-sign visible-md-inline visible-sm-inline"

--- a/packages/core/src/loadBalancer/CreateLoadBalancerButton.tsx
+++ b/packages/core/src/loadBalancer/CreateLoadBalancerButton.tsx
@@ -1,14 +1,11 @@
 import React from 'react';
 
-import type { IAccountDetails } from '../account';
 import type { Application } from '../application';
-import type { ICloudProviderConfig } from '../cloudProvider';
-import { CloudProviderRegistry, ProviderSelectionService } from '../cloudProvider';
+import { ProviderSelectionService } from '../cloudProvider';
 import type { ILoadBalancer } from '../domain';
 import type { ILoadBalancerUpsertCommand } from './loadBalancer.write.service';
 import type { IModalComponentProps } from '../presentation';
 import { Tooltip } from '../presentation';
-import { ModalInjector } from '../reactShims';
 
 export interface ILoadBalancerModalProps extends IModalComponentProps {
   className?: string;
@@ -38,59 +35,11 @@ export class CreateLoadBalancerButton extends React.Component<ICreateLoadBalance
     });
   }
 
-  private createLoadBalancerProviderFilterFn = (
-    _app: Application,
-    _acc: IAccountDetails,
-    provider: ICloudProviderConfig,
-  ): boolean => {
-    const lbConfig = provider.loadBalancer;
-    return (
-      lbConfig &&
-      (lbConfig.CreateLoadBalancerModal ||
-        (lbConfig.createLoadBalancerTemplateUrl && lbConfig.createLoadBalancerController))
-    );
-  };
-
-  private createLoadBalancer = (): void => {
-    const { app } = this.props;
-    ProviderSelectionService.selectProvider(app, 'loadBalancer', this.createLoadBalancerProviderFilterFn).then(
-      (selectedProvider) => {
-        const provider = CloudProviderRegistry.getValue(selectedProvider, 'loadBalancer');
-
-        if (provider.CreateLoadBalancerModal) {
-          provider.CreateLoadBalancerModal.show({
-            app: app,
-            application: app,
-            forPipelineConfig: false,
-            loadBalancer: null,
-            isNew: true,
-          });
-        } else {
-          // angular
-          ModalInjector.modalService
-            .open({
-              templateUrl: provider.createLoadBalancerTemplateUrl,
-              controller: `${provider.createLoadBalancerController} as ctrl`,
-              size: 'lg',
-              windowClass: 'modal-z-index',
-              resolve: {
-                application: () => this.props.app,
-                loadBalancer: (): ILoadBalancer => null,
-                isNew: () => true,
-                forPipelineConfig: () => false,
-              },
-            })
-            .result.catch(() => {});
-        }
-      },
-    );
-  };
-
   public render() {
     if (!this.state.isDisabled) {
       return (
         <div>
-          <button className="btn btn-sm btn-default" onClick={this.createLoadBalancer}>
+          <button className="btn btn-sm btn-default" disabled={true}>
             <span className="glyphicon glyphicon-plus-sign visible-lg-inline" />
             <Tooltip value="Create Load Balancer">
               <span className="glyphicon glyphicon-plus-sign visible-md-inline visible-sm-inline" />

--- a/packages/core/src/loadBalancer/CreateLoadBalancerButton.tsx
+++ b/packages/core/src/loadBalancer/CreateLoadBalancerButton.tsx
@@ -39,7 +39,7 @@ export class CreateLoadBalancerButton extends React.Component<ICreateLoadBalance
     if (!this.state.isDisabled) {
       return (
         <div>
-          <button className="btn btn-sm btn-default" disabled={true}>
+          <button className="btn btn-sm btn-default" disabled>
             <span className="glyphicon glyphicon-plus-sign visible-lg-inline" />
             <Tooltip value="Create Load Balancer">
               <span className="glyphicon glyphicon-plus-sign visible-md-inline visible-sm-inline" />

--- a/packages/core/src/securityGroup/CreateSecurityGroupButton.tsx
+++ b/packages/core/src/securityGroup/CreateSecurityGroupButton.tsx
@@ -1,70 +1,12 @@
 import * as React from 'react';
 
-import type { IAccountDetails } from '../account';
-import type { Application } from '../application';
-import type { ICloudProviderConfig } from '../cloudProvider';
-import { CloudProviderRegistry, ProviderSelectionService } from '../cloudProvider';
-import { SETTINGS } from '../config/settings';
 import { FirewallLabels } from './label/FirewallLabels';
 import { Tooltip } from '../presentation';
-import { ModalInjector } from '../reactShims';
 
-const providerFilterFn = (_application: Application, _account: IAccountDetails, provider: ICloudProviderConfig) => {
-  const sgConfig = provider.securityGroup;
-  return (
-    sgConfig &&
-    (sgConfig.CreateSecurityGroupModal ||
-      (sgConfig.createSecurityGroupTemplateUrl && sgConfig.createSecurityGroupController))
-  );
-};
-
-const getDefaultCredentials = (app: Application, provider: string) =>
-  app.defaultCredentials[provider] || SETTINGS.providers[provider].defaults.account;
-const getDefaultRegion = (app: Application, provider: string) =>
-  app.defaultRegions[provider] || SETTINGS.providers[provider].defaults.region;
-
-const getAngularModalOptions = (provider: any, selectedProvider: string, app: Application) => ({
-  templateUrl: provider.createSecurityGroupTemplateUrl,
-  controller: `${provider.createSecurityGroupController} as ctrl`,
-  windowClass: 'modal-z-index',
-  size: 'lg',
-  resolve: {
-    securityGroup: () => {
-      return {
-        credentials: getDefaultCredentials(app, selectedProvider),
-        subnet: 'none',
-        regions: [getDefaultRegion(app, selectedProvider)],
-      };
-    },
-    application: () => {
-      return app;
-    },
-  },
-});
-
-const getReactModalOptions = (selectedProvider: string, app: Application) => ({
-  credentials: getDefaultCredentials(app, selectedProvider),
-  application: app,
-  isNew: true,
-});
-
-export const CreateSecurityGroupButton = ({ app }: { app: Application }) => {
-  const createSecurityGroup = (): void => {
-    ProviderSelectionService.selectProvider(app, 'securityGroup', providerFilterFn).then((selectedProvider) => {
-      const provider = CloudProviderRegistry.getValue(selectedProvider, 'securityGroup');
-
-      if (provider.CreateSecurityGroupModal) {
-        provider.CreateSecurityGroupModal.show(getReactModalOptions(selectedProvider, app));
-      } else {
-        // angular
-        ModalInjector.modalService.open(getAngularModalOptions(provider, selectedProvider, app)).result.catch(() => {});
-      }
-    });
-  };
-
+export const CreateSecurityGroupButton = () => {
   return (
     <div>
-      <button className="btn btn-sm btn-default" onClick={createSecurityGroup}>
+      <button className="btn btn-sm btn-default" disabled={true}>
         <span className="glyphicon glyphicon-plus-sign visible-lg-inline" />
         <Tooltip value="Create Load Balancer">
           <span className="glyphicon glyphicon-plus-sign visible-md-inline visible-sm-inline" />

--- a/packages/dcos/src/loadBalancer/details/details.html
+++ b/packages/dcos/src/loadBalancer/details/details.html
@@ -27,7 +27,7 @@
             Load Balancer Actions <span class="caret"></span>
           </button>
           <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-            <li><a href ng-click="ctrl.editLoadBalancer()">Edit Load Balancer</a></li>
+            <li class="disabled"><a>Edit Load Balancer</a></li>
             <li ng-if="!loadBalancer.instances.length">
               <a href ng-click="ctrl.deleteLoadBalancer()">Delete Load Balancer</a>
             </li>

--- a/packages/google/src/loadBalancer/details/loadBalancerDetails.html
+++ b/packages/google/src/loadBalancer/details/loadBalancerDetails.html
@@ -40,7 +40,7 @@
             Load Balancer Actions <span class="caret"></span>
           </button>
           <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-            <li><a href ng-click="ctrl.editLoadBalancer()">Edit Load Balancer</a></li>
+            <li class="disabled"><a>Edit Load Balancer</a></li>
             <li ng-if="!loadBalancer.instances.length">
               <a href ng-click="ctrl.deleteLoadBalancer()">Delete Load Balancer</a>
             </li>

--- a/packages/kubernetes/src/instance/details/details.html
+++ b/packages/kubernetes/src/instance/details/details.html
@@ -16,8 +16,8 @@
           <li>
             <a href ng-click="ctrl.deleteInstance()">Delete</a>
           </li>
-          <li>
-            <a href ng-click="ctrl.editInstance()">Edit</a>
+          <li class="disabled">
+            <a>Edit</a>
           </li>
         </ul>
       </div>

--- a/packages/kubernetes/src/loadBalancer/details/details.html
+++ b/packages/kubernetes/src/loadBalancer/details/details.html
@@ -47,8 +47,8 @@
           <li>
             <a href ng-click="ctrl.deleteLoadBalancer()">Delete</a>
           </li>
-          <li>
-            <a href ng-click="ctrl.editLoadBalancer()">Edit</a>
+          <li class="disabled">
+            <a>Edit</a>
           </li>
           <render-if-feature feature="entityTags">
             <add-entity-tag-links

--- a/packages/kubernetes/src/serverGroup/details/details.html
+++ b/packages/kubernetes/src/serverGroup/details/details.html
@@ -43,8 +43,8 @@
           {{ctrl.serverGroup.kind | robotToHuman}} Actions <span class="caret"></span>
         </button>
         <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-          <li ng-if="ctrl.canEditServerGroup()">
-            <a href ng-click="ctrl.editServerGroup()"> Edit </a>
+          <li class="disabled">
+            <a> Edit </a>
           </li>
           <li ng-if="ctrl.canScaleServerGroup()">
             <a href ng-click="ctrl.scaleServerGroup()"> Scale </a>

--- a/packages/kubernetes/src/serverGroupManager/details/details.html
+++ b/packages/kubernetes/src/serverGroupManager/details/details.html
@@ -61,8 +61,8 @@
             server-group-manager="ctrl.serverGroupManager"
           ></kubernetes-rolling-restart>
           <li role="presentation" class="divider"></li>
-          <li>
-            <a href ng-click="ctrl.editServerGroupManager()"> Edit </a>
+          <li class="disabled">
+            <a> Edit </a>
           </li>
           <li>
             <a href ng-click="ctrl.deleteServerGroupManager()"> Delete </a>

--- a/packages/oracle/src/loadBalancer/details/loadBalancerDetail.html
+++ b/packages/oracle/src/loadBalancer/details/loadBalancerDetail.html
@@ -27,7 +27,7 @@
             Load Balancer Actions <span class="caret"></span>
           </button>
           <ul class="dropdown-menu" uib-dropdown-menu role="menu">
-            <li><a href ng-click="ctrl.editLoadBalancer()">Edit Load Balancer</a></li>
+            <li class="disabled"><a>Edit Load Balancer</a></li>
             <li ng-if="!loadBalancer.serverGroups.length">
               <a href ng-click="ctrl.deleteLoadBalancer()">Delete Load Balancer</a>
             </li>

--- a/packages/titus/src/serverGroup/details/serverGroupDetails.html
+++ b/packages/titus/src/serverGroup/details/serverGroupDetails.html
@@ -46,7 +46,7 @@
             <li><a href ng-if="!serverGroup.isDisabled" ng-click="ctrl.disableServerGroup()">Disable</a></li>
             <li><a href ng-if="serverGroup.isDisabled" ng-click="ctrl.enableServerGroup()">Enable</a></li>
             <li><a href ng-click="ctrl.destroyServerGroup()">Destroy</a></li>
-            <li><a href ng-click="ctrl.cloneServerGroup()">Clone</a></li>
+            <li class="disabled"><a>Clone</a></li>
             <add-entity-tag-links
               component="serverGroup"
               application="ctrl.application"


### PR DESCRIPTION
NOTE: I'm merging the changes into the branch release-1.29.x so that when other changes are merged into the upstream branch in spinnaker/deck we should just be able to merge them directly into this branch with our changes.

Disables the same components that are usually disabled by github.com/one-thd/thd-deck/disable.sh

A few of the files disabled won't affect our spinnaker such as in /titus/ and /dcos/ but I figured I should fully disable every case that the disable.sh script would just in case.  


The readme changes include all the steps that I used for creating and testing new deck images and I figure will most likely be added to cd-internal-docs in the spinnaker upgrade section.